### PR TITLE
最新の活動内容にあわせて、文言をアップデートしました：text changed according to current status

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -31,7 +31,7 @@
       <div class="header">
         <ul class="nav nav-pills pull-right">
           <li class="active"><a href="#">トップ</a></li>
-          <li><a href="#">Dojoの流れ</a></li>
+          <li><a href="#">Dojoの仕組み</a></li>
           <li><a href="#">メンバー</a></li>
           <li><a href="#">申し込み</a></li>
         </ul>
@@ -43,8 +43,10 @@
       <div class="jumbotron">
         <div class="cover">
         <div class="jumbotron-inner">
-          <h1><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>世界中に、仲間を作ろう。</h1>
-          <p class="lead">世界中に、あなたと同じくらい、そして あなたよりもがんばっている仲間がいる。<br/>独学道場は、あなたと彼らの間に絆をつくる、世界最高のオンライン学習コミュニティです。</p>
+          <h1><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>いつでも、誰かがいる場所。</h1>
+          <p class="lead">
+            世界中に、あなたと同じくらい、そして あなたよりもがんばっている仲間がいる。<br/>
+            ここは、あなたと彼らが同じバーチャルスペースを共有するオンライン自習室です。</p>
           <!-- <p><a class="btn btn-lg btn-success" href="#">Splendid!</a></p> -->
         </div>
         </div>
@@ -52,33 +54,47 @@
 
       <div class="row marketing">
         <div class="col-lg-12">
-          <h3>Dojoの流れ</h3>
-          <p class="lead">リアルでもオンラインでも一人の時間を効率よく使いましょう。</p>
+          <h3>Dojoの仕組み</h3>
+          <p class="lead">独学道場は、あなたが「手を動かして何かを学ぶ時間」を最大化させるための場所です。</p>
           <div class="flow-section">
             <div class="flow-image" style="background-image: url('https://placeholdit.imgix.net/~text?txtsize=33&txt=350%C3%97150&w=350&h=150');"></div>
             <div class="flow-body">
-              <h4>あなた専用のプランを考えましょう</h4>
-              <p>「師匠」が、あなたがまず取り組むべき学習内容が詰まった「特訓ノート」を用意します。集中して学習する日時場所を確保する「道場参加シフト」を一緒につくりましょう。</p>
+              <h4>程よい緊張感が、あなたの独学時間の質を変えます。</h4>
+              <p>
+                私たちの行動は、環境に絶えず影響を受けています。
+                少人数のグループビデオチャットが絶えず行われているオンライン自習部屋で、程よい緊張感を持ちながら手を動かしましょう。
+              </p>
             </div>
           </div>
           <div class="flow-section odd">
             <div class="flow-image" style="background-image: url('https://placeholdit.imgix.net/~text?txtsize=33&txt=350%C3%97150&w=350&h=150');"></div>
             <div class="flow-body">
-              <h4>適度なプレッシャーの中で手を動かします</h4>
-              <p>道場活動中、同期や師匠に「現在やっていること」を宣言してもらいます。あなたの進捗を、みんなが期待しています。私たち道場主催者は、あなたの進捗をこまめにウェブ上で発信します</p>
+              <h4>共に時間を過ごす仲間と、情報交換をしましょう。</h4>
+              <p>
+                独学が思うように進まないとき、興味・関心が似通った学習仲間の「実体験に基づくアドバイス」がもっとも助けになります。
+                検索して出てくる膨大な情報を選り分け、「今のあなたの助けになる情報はなんなのか」という観点で情報交換をします。
+              </p>
             </div>
           </div>
           <div class="flow-section">
             <div class="flow-image" style="background-image: url('https://placeholdit.imgix.net/~text?txtsize=33&txt=350%C3%97150&w=350&h=150');"></div>
             <div class="flow-body">
-              <h4>成果発表に向けてモチベーションを高めましょう</h4>
-              <p>「師匠」が、あなたがまず取り組むべき学習内容が詰まった「特訓ノート」を用意します。集中して学習する日時場所を確保する「道場参加シフト」を一緒につくりましょう。</p>
+              <h4>成果発表を利用し「次のステージ」に進みましょう。</h4>
+              <p>
+                定期的に、先輩エンジニア、あのテック企業、そして絆が生まれた独学仲間が集まる「成果発表会」を開きます。
+                自分の知的好奇心を信じて、情熱を思いっきりぶつけましょう。
+                批評家は会場から排除します。自分がもっともワクワクすることを、心から楽しんで発表してください。
+                その先に、「次のステージ」があると私たちは信じています。
+              </p>
             </div>
           </div>
         </div>
       </div>
 
       <div class="row">
+        <div style="margin-left: 50px; font-size: 20px;">
+          Dojoの風景
+        </div>
         <div class="col-xs-12 thumbnails">
           <div class="thumbnail" style="background-image: url('https://placeholdit.imgix.net/~text?txtsize=33&txt=350%C3%97150&w=350&h=150');"></diV>
           <div class="thumbnail" style="background-image: url('https://placeholdit.imgix.net/~text?txtsize=33&txt=350%C3%97150&w=350&h=150');"></diV>
@@ -91,8 +107,8 @@
 
       <div class="row marketing">
         <div class="col-lg-12">
-          <h3>メンバー</h3>
-          <p class="lead">Dokugaku Dojoのメンバーです。世界中の独学マスターを募集してます。</p>
+          <h3>主催者</h3>
+          <p class="lead">Dokugaku Dojoの主催者です。世界中の独学マスターと交流しています。</p>
 
           <div class="member-section">
             <div class="member">
@@ -157,7 +173,7 @@
         <div class="row">
           <div class="col-lg-4">
             <p><img src="./images/dokugaku-dojo-logo-2.png" alt="Dokugaku Dojo" class="logo" /></p>
-            <p>独学道場は、あなたと彼らの間に絆をつくる、世界最高のオンライン学習コミュニティです。</p>
+            <p>Dokugaku Dojo - いつでも誰かがいるオンライン自習室</p>
           </div>
           <div class="col-lg-4">
             <ul class="list-unstyled">


### PR DESCRIPTION
## もうひとつリクエスト

メンバーセクションにおいて、マウスオーバーしないと自己紹介が出ないのは、もしかしたら要求リテラシーレベルが高すぎるかもしれません。

テキストとして、そのまま、下に書くことできるでしょうか？
